### PR TITLE
use string default for `@additionalChartOptions`

### DIFF
--- a/lib/google-image-charts.rb
+++ b/lib/google-image-charts.rb
@@ -22,7 +22,7 @@ module GoogleImageCharts
       
       # These might be set by someone who knows what they are doing, perhaps after reading:
       # https://developers.google.com/chart/image/docs/chart_params
-      @additionalChartOptions = chartOptionsHash[:additionalOptions]
+      @additionalChartOptions = chartOptionsHash.fetch(:additionalOptions, '')
       
       # Support the Google Image Charts POST method which allows up to 16K of chart data
       # https://developers.google.com/chart/image/docs/post_requests


### PR DESCRIPTION
Hey there!

I know I'm a few years late, but I hit this building a pie chart.

I was getting `no implicit conversion of nil into String` when we tried to add all the strings together down on line 81.

All the best and let me know if there's anything more I can do to merge this. :two_hearts: :cupid: 
