### PR TITLE
Move to Image Charts as Google Image Charts is deprecated and could be shutdown at any time

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,8 +1,8 @@
-# Google Image Charts
+# ~~Google~~ Image Charts
 
-Ruby library for interfacing with Google's Image Chart API. (Part of the Google Image Visualization API.)
+Ruby library for interfacing with ~~Google's~~ [Image-Charts](https://image-charts.com) API (a drop-in-replacement for the [deprecated Google Image Charts](https://developers.googleblog.com/2012/04/changes-to-deprecation-policies-and-api.html)).
 
-Google Image Charts allows a user to enter series data into a query string and retrieve a PNG or SVG image graph. See [http://code.google.com/apis/chart/image/](http://code.google.com/apis/chart/image/) for more information.
+Image Charts allows a user to enter series data into a query string and retrieve a PNG or SVG image graph. See [image-charts.com/documentation](image-charts.com/documentation) for more information.
 
 Right now only Line Graphs and Pie Charts are supported. Let me know if you would like to contribute!
 
@@ -29,16 +29,16 @@ Right now only Line Graphs and Pie Charts are supported. Let me know if you woul
 	
 	# Use it!
 	chartUrl = lineGraph.chart_url
-	# => "http://chart.apis.google.com/chart?cht=lc&chs=400x250&chd=t:4,5,10,6,2,9%7C2,2,12,9,11,1&chdl=Series%201%7CSeries%202&chdlp=b&chtt=Test%20chart&chco=a&chds=a&chxt=x,y"
-	
+	# => "http://image-charts.com/chart?cht=lc&chs=400x250&chd=t:4,5,10,6,2,9%7C2,2,12,9,11,1&chdl=Series%201%7CSeries%202&chdlp=b&chtt=Test%20chart&chds=a&chxt=x,y"
+
 	imageTag = lineGraph.html_img_tag
-	# => "<img src='http://chart.apis.google.com/chart?cht=lc&chs=400x250&chd=t:4,5,10,6,2,9%7C2,2,12,9,11,1&chdl=Series%201%7CSeries%202&chdlp=b&chtt=Test%20chart&chco=a&chds=a&chxt=x,ycht=lc&chs=400x250&chd=t:4,5,10,6,2,9%7C2,2,12,9,11,1&chdl=Series%201%7CSeries%202&chdlp=b&chtt=Test%20chart&chco=a&chds=a&chxt=x,y' alt='Test chart' height='250' width='400' />"
-	
+	# => "<img src='http://image-charts.com/chart?cht=lc&chs=400x250&chd=t:4,5,10,6,2,9%7C2,2,12,9,11,1&chdl=Series%201%7CSeries%202&chdlp=b&chtt=Test%20chart&chds=a&chxt=x,y' alt='Test chart' height='250' width='400' />"
+
 	# Make it prettier
 	lineGraph.chartColors = ["5CB8E6","E68A00"]
 
 ### Result
-<div align="center"><img src='http://chart.apis.google.com/chart?cht=lc&chs=400x250&chd=t:4,5,10,6,2,9%7C2,2,12,9,11,1&chdl=Series%201%7CSeries%202&chdlp=b&chtt=Test%20chart&chco=a&chds=a&chxt=x,ycht=lc&chs=400x250&chd=t:4,5,10,6,2,9%7C2,2,12,9,11,1&chdl=Series%201%7CSeries%202&chdlp=b&chtt=Test%20chart&chco=5CB8E6,E68A00&chds=a&chxt=x,y' alt='Test chart' height='250' width='400' /></div>
+<div align="center"><img src='http://image-charts.com/chart?cht=lc&chs=400x250&chd=t:4,5,10,6,2,9%7C2,2,12,9,11,1&chdl=Series%201%7CSeries%202&chdlp=b&chtt=Test%20chart&chds=a' alt='Test chart' height='250' width='400' /></div>
 
 ## Pie Chart Example
 ### Code Sample
@@ -60,13 +60,13 @@ Right now only Line Graphs and Pie Charts are supported. Let me know if you woul
 	
 	# Use it!
 	chartUrl = pieChart.chart_url
-	# => "http://chart.apis.google.com/chart?cht=p&chs=200x200&chd=t:15,85&chdl=This%20Stinks!%7CThis%20is%20awesome!&chdlp=b&chtt=Pie%20Chart%20Test&chco=5CB8E6,E68A00&chds=a"
-	
+	# => "http://image-charts.com/chart?cht=p&chs=200x200&chd=t:15,85&chdl=This%20Stinks!%7CThis%20is%20awesome!&chdlp=b&chtt=Pie%20Chart%20Test&chco=5CB8E6,E68A00&chds=a"
+
 	imageTag = pieChart.html_img_tag
-	# => "<img src='http://chart.apis.google.com/chart?cht=p&chs=200x200&chd=t:15,85&chdl=This%20Stinks!%7CThis%20is%20awesome!&chdlp=b&chtt=Pie%20Chart%20Test&chco=5CB8E6,E68A00&chds=acht=p&chs=200x200&chd=t:15,85&chdl=This%20Stinks!%7CThis%20is%20awesome!&chdlp=b&chtt=Pie%20Chart%20Test&chco=5CB8E6,E68A00&chds=a' alt='Pie Chart Test' height='200' width='200' />"
+	# => "<img src='http://image-charts.com/chart?cht=p&chs=200x200&chd=t:15,85&chdl=This%20Stinks!%7CThis%20is%20awesome!&chdlp=b&chtt=Pie%20Chart%20Test&chco=5CB8E6,E68A00&chds=a' alt='Pie Chart Test' height='200' width='200' />"
 
 ### Result
-<div align="center"><img src='http://chart.apis.google.com/chart?cht=p&chs=200x200&chd=t:15,85&chdl=This%20Stinks!%7CThis%20is%20awesome!&chdlp=b&chtt=Pie%20Chart%20Test&chco=5CB8E6,E68A00&chds=acht=p&chs=200x200&chd=t:15,85&chdl=This%20Stinks!%7CThis%20is%20awesome!&chdlp=b&chtt=Pie%20Chart%20Test&chco=5CB8E6,E68A00&chds=a' alt='Pie Chart Test' height='200' width='200' /></div>
+<div align="center"><img src='http://image-charts.com/chart?cht=p&chs=200x200&chd=t:15,85&chdl=This%20Stinks!%7CThis%20is%20awesome!&chdlp=b&chtt=Pie%20Chart%20Test&chco=5CB8E6,E68A00&chds=a' alt='Pie Chart Test' height='200' width='200' /></div>
 
 ## Additional Options
 
@@ -74,7 +74,7 @@ Right now only Line Graphs and Pie Charts are supported. Let me know if you woul
 As of 0.4 there is support for Google's POST method allowing up to 16K of data to be graphed. Simply set `:usePost = true` in your chartOptions hash and call `get_chart`. Be sure to set your content return type to PNG for this to work in a browser.
 
 ### Additional Options
-There are plenty of features that this library does not yet make available. If you'd like to use the simplicity of the library, but pass in one of the additional features documented on [https://developers.google.com/chart/image/docs/chart_params](Google's Chart Feature List) you can now pass those as a string into your :additionalOptions element in the chartOptions hash.
+There are plenty of features that this library does not yet make available. If you'd like to use the simplicity of the library, but pass in one of the additional features documented on [https://image-charts.com/documentation](Image-charts Feature List) you can now pass those as a string into your :additionalOptions element in the chartOptions hash.
 
 Each additional line element should be separated by an '&'
 
@@ -87,4 +87,3 @@ Each additional line element should be separated by an '&'
 		:colors => ["5CB8E6","E68A00"],
 		:additionalOptions => "&chls=5" #Makes the line bolder
 	}
-   

--- a/lib/google-image-charts.rb
+++ b/lib/google-image-charts.rb
@@ -4,9 +4,9 @@ module GoogleImageCharts
   
   class ChartBase
     attr_accessor :chartTitle, :chartWidth, :chartHeight, :chartLabels, :chartColors, :additionalChartOptions, :usePost
-    
-    CHART_URI_BASE = "http://chart.apis.google.com/chart?"
-    
+
+    CHART_URI_BASE = "http://image-charts.com/chart?"
+
     def initialize(chartOptionsHash)
       @chartSpecificOptions = ""  # Should be overridden by child-classes
       


### PR DESCRIPTION
Hello @cbrito!

It's a simple replacement but make the library futur-proof :)


https://www.image-charts.com/